### PR TITLE
[#13] Integrate logger into the project via cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,14 +14,12 @@ FetchContent_Declare(
 FetchContent_Declare(
 	logger
 	GIT_REPOSITORY https://github.com/temikfart/logger.git
-	GIT_TAG e1e6d1122815b3b6b173e361bac0f3be5d4d2a6c
+	GIT_TAG 5954a903b1b8227cac89ddc04ead81225ed90821 # release/1.0.0
 )
-FetchContent_MakeAvailable(json)
-FetchContent_MakeAvailable(logger)
+FetchContent_MakeAvailable(json logger)
 
 include_directories(include)
 
 add_executable(coolstory_gram_client
             src/main.cpp)
-target_link_libraries(coolstory_gram_client PRIVATE nlohmann_json::nlohmann_json)
-target_link_libraries(coolstory_gram_client PRIVATE liblogger)
+target_link_libraries(coolstory_gram_client PRIVATE nlohmann_json::nlohmann_json liblogger)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,17 @@ FetchContent_Declare(
 	GIT_REPOSITORY https://github.com/nlohmann/json.git
 	GIT_TAG bc889afb4c5bf1c0d8ee29ef35eaaf4c8bef8a5d # release/3.11.2
 )
+FetchContent_Declare(
+	logger
+	GIT_REPOSITORY https://github.com/temikfart/logger.git
+	GIT_TAG e1e6d1122815b3b6b173e361bac0f3be5d4d2a6c
+)
 FetchContent_MakeAvailable(json)
+FetchContent_MakeAvailable(logger)
 
 include_directories(include)
 
 add_executable(coolstory_gram_client
             src/main.cpp)
 target_link_libraries(coolstory_gram_client PRIVATE nlohmann_json::nlohmann_json)
-
+target_link_libraries(coolstory_gram_client PRIVATE liblogger)


### PR DESCRIPTION
Now we can use [logger](https://github.com/temikfart/logger) in our project by simply `#include <log.hpp>` wherever we wont.
I'm added few lines to `CMakeLists.txt` so now logging library downloading automatically with `FetchContent` and linking to executable.